### PR TITLE
Make quadsort and fluxsort compilable as C++ code

### DIFF
--- a/src/fluxsort.c
+++ b/src/fluxsort.c
@@ -480,7 +480,7 @@ void FUNC(flux_partition)(VAR *array, VAR *swap, VAR *ptx, VAR *piv, size_t nmem
 	}
 }
 
-void FUNC(fluxsort)(void *array, size_t nmemb, CMPFUNC *cmp)
+void FUNC(fluxsort)(VAR *array, size_t nmemb, CMPFUNC *cmp)
 {
 	VAR *pta = (VAR *) array;
 
@@ -503,7 +503,7 @@ void FUNC(fluxsort)(void *array, size_t nmemb, CMPFUNC *cmp)
 	}
 }
 
-void FUNC(fluxsort_swap)(void *array, void *swap, size_t swap_size, size_t nmemb, CMPFUNC *cmp)
+void FUNC(fluxsort_swap)(VAR *array, VAR *swap, size_t swap_size, size_t nmemb, CMPFUNC *cmp)
 {
 	VAR *pta = (VAR *) array;
 	VAR *pts = (VAR *) swap;

--- a/src/fluxsort.h
+++ b/src/fluxsort.h
@@ -233,23 +233,23 @@ void fluxsort(void *array, size_t nmemb, size_t size, CMPFUNC *cmp)
 	switch (size)
 	{
 		case sizeof(char):
-			fluxsort8(array, nmemb, cmp);
+			fluxsort8((char*)array, nmemb, cmp);
 			return;
 
 		case sizeof(short):
-			fluxsort16(array, nmemb, cmp);
+			fluxsort16((short*)array, nmemb, cmp);
 			return;
 
 		case sizeof(int):
-			fluxsort32(array, nmemb, cmp);
+			fluxsort32((int*)array, nmemb, cmp);
 			return;
 
 		case sizeof(long long):
-			fluxsort64(array, nmemb, cmp);
+			fluxsort64((long long*)array, nmemb, cmp);
 			return;
 #if (DBL_MANT_DIG < LDBL_MANT_DIG)
 		case sizeof(long double):
-			fluxsort128(array, nmemb, cmp);
+			fluxsort128((long double*)array, nmemb, cmp);
 			return;
 #endif
 
@@ -274,16 +274,16 @@ void fluxsort_prim(void *array, size_t nmemb, size_t size)
 	switch (size)
 	{
 		case 4:
-			fluxsort_int32(array, nmemb, NULL);
+			fluxsort_int32((int*)array, nmemb, NULL);
 			return;
 		case 5:
-			fluxsort_uint32(array, nmemb, NULL);
+			fluxsort_uint32((unsigned int*)array, nmemb, NULL);
 			return;
 		case 8:
-			fluxsort_int64(array, nmemb, NULL);
+			fluxsort_int64((long long*)array, nmemb, NULL);
 			return;
 		case 9:
-			fluxsort_uint64(array, nmemb, NULL);
+			fluxsort_uint64((unsigned long long*)array, nmemb, NULL);
 			return;
 		default:
 			assert(size == sizeof(int) || size == sizeof(int) + 1 || size == sizeof(long long) || size == sizeof(long long) + 1);

--- a/src/quadsort.c
+++ b/src/quadsort.c
@@ -1064,7 +1064,7 @@ void FUNC(blit_merge)(VAR *array, VAR *swap, size_t swap_size, size_t nmemb, siz
 //└─────────────────────────────────────────────────────────────────────────┘//
 ///////////////////////////////////////////////////////////////////////////////
 
-void FUNC(quadsort)(void *array, size_t nmemb, CMPFUNC *cmp)
+void FUNC(quadsort)(VAR *array, size_t nmemb, CMPFUNC *cmp)
 {
 	VAR *pta = (VAR *) array;
 
@@ -1102,7 +1102,7 @@ void FUNC(quadsort)(void *array, size_t nmemb, CMPFUNC *cmp)
 	}
 }
 
-void FUNC(quadsort_swap)(void *array, void *swap, size_t swap_size, size_t nmemb, CMPFUNC *cmp)
+void FUNC(quadsort_swap)(VAR *array, VAR *swap, size_t swap_size, size_t nmemb, CMPFUNC *cmp)
 {
 	VAR *pta = (VAR *) array;
 	VAR *pts = (VAR *) swap;

--- a/src/quadsort.h
+++ b/src/quadsort.h
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <float.h>
+#include <string.h>
 //#include <stdalign.h>
 
 typedef int CMPFUNC (const void *a, const void *b);
@@ -316,23 +317,23 @@ void quadsort(void *array, size_t nmemb, size_t size, CMPFUNC *cmp)
 	switch (size)
 	{
 		case sizeof(char):
-			quadsort8(array, nmemb, cmp);
+			quadsort8((char*)array, nmemb, cmp);
 			return;
 
 		case sizeof(short):
-			quadsort16(array, nmemb, cmp);
+			quadsort16((short*)array, nmemb, cmp);
 			return;
 
 		case sizeof(int):
-			quadsort32(array, nmemb, cmp);
+			quadsort32((int*)array, nmemb, cmp);
 			return;
 
 		case sizeof(long long):
-			quadsort64(array, nmemb, cmp);
+			quadsort64((long long*)array, nmemb, cmp);
 			return;
 #if (DBL_MANT_DIG < LDBL_MANT_DIG)
 		case sizeof(long double):
-			quadsort128(array, nmemb, cmp);
+			quadsort128((long double*)array, nmemb, cmp);
 			return;
 #endif
 //		case sizeof(struct256):
@@ -373,16 +374,16 @@ void quadsort_prim(void *array, size_t nmemb, size_t size)
 	switch (size)
 	{
 		case 4:
-			quadsort_int32(array, nmemb, NULL);
+			quadsort_int32((int*)array, nmemb, NULL);
 			return;
 		case 5:
-			quadsort_uint32(array, nmemb, NULL);
+			quadsort_uint32((unsigned int*)array, nmemb, NULL);
 			return;
 		case 8:
-			quadsort_int64(array, nmemb, NULL);
+			quadsort_int64((long long*)array, nmemb, NULL);
 			return;
 		case 9:
-			quadsort_uint64(array, nmemb, NULL);
+			quadsort_uint64((unsigned long long*)array, nmemb, NULL);
 			return;
 		default:
 			assert(size == sizeof(int) || size == sizeof(int) + 1 || size == sizeof(long long) || size == sizeof(long long) + 1);


### PR DESCRIPTION
There are slight implicit cast differences depending if code is compiled as C and C++ code. With some minor changes quadsort and fluxsort can be made to support both compiling as C and C++.